### PR TITLE
add set & map support for abigen

### DIFF
--- a/include/eosio/gen.hpp
+++ b/include/eosio/gen.hpp
@@ -103,10 +103,10 @@ struct generation_utils {
 
       return is_specialization;
    }
-   inline clang::QualType get_template_argument( const clang::QualType& type ) {
+   inline clang::QualType get_template_argument( const clang::QualType& type, int index = 0 ) {
       auto ret = [&](const clang::Type* t) {
          if (auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(t))
-            return tst->getArg(0).getAsType();
+            return tst->getArg(index).getAsType();
          std::cout << "Internal error, wrong type of template specialization\n";
          error_handler();
       };
@@ -119,11 +119,14 @@ struct generation_utils {
       clang::QualType newType = type;
       std::string type_str = newType.getNonReferenceType().getAsString();
       int i = type_str.length()-1;
+      int template_nested = 0;
       for (; i > 0; i--) {
-         if (type_str[i] == ':') {
+         if (type_str[i] == '>') ++template_nested;
+         if (type_str[i] == '<') --template_nested;
+         if (type_str[i] == ':' && template_nested == 0) {
             return type_str.substr(i+1); 
          }
-         if (type_str[i] == ' ') {
+         if (type_str[i] == ' ' && template_nested == 0) {
             static const std::string valid_prefixs[] = {"long", "signed", "unsigned" };
             bool valid = false;
             for (auto &s : valid_prefixs) {
@@ -197,12 +200,23 @@ struct generation_utils {
    }
 
    inline std::string translate_type( const clang::QualType& type ) {
-      if ( is_template_specialization( type, {"vector"} ) ) {
+      if ( is_template_specialization( type, {"vector", "set"} ) ) {
          auto t =_translate_type(get_template_argument( type ));
          return t=="int8" ? "bytes" : t+"[]";
       }
       else if ( is_template_specialization( type, {"optional"} ) )
          return _translate_type(get_template_argument( type ))+"?";
+      else if ( is_template_specialization( type, {"map"} )) {
+         auto t0 = _translate_type(get_template_argument( type ));
+         auto t1 = _translate_type(get_template_argument( type, 1));
+         std::string ret = "pair_" + t0 + "_" + t1 + "[]";
+         std::replace(ret.begin(), ret.end(), '<', '_');
+         std::replace(ret.begin(), ret.end(), '>', '_');
+         std::replace(ret.begin(), ret.end(), ',', '_');
+         std::replace(ret.begin(), ret.end(), ' ', '_');
+         std::replace(ret.begin(), ret.end(), ':', '_');
+         return ret;
+      }
       return _translate_type( type );
    }
 
@@ -263,7 +277,7 @@ struct generation_utils {
    
    inline bool is_builtin_type( const clang::QualType& t ) {
       std::string nt = translate_type(t);
-      return is_builtin_type(nt) || is_name_type(nt) || is_template_specialization(t, {"vector", "optional"});
+      return is_builtin_type(nt) || is_name_type(nt) || is_template_specialization(t, {"vector", "set", "optional"});
    } 
 
    inline bool is_cxx_record( const clang::QualType& t ) {
@@ -284,6 +298,7 @@ struct generation_utils {
    inline bool is_aliasing( const clang::QualType& t ) {
       if (is_name_type(get_base_type_name(t)))
          return true;
+      if (get_base_type_name(t).find("<") != std::string::npos) return false;
       return get_base_type_name(t).compare(get_type_alias(t)) != 0;
    }
 };

--- a/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
+++ b/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
@@ -109,8 +109,17 @@ class abigen : public generation_utils {
 
    void add_map(const clang::QualType& type) {
       for (int i = 0; i < 2; ++i) {
-         if ( get_template_argument(type, i)->isRecordType() )
-            add_struct(get_template_argument(type, i).getTypePtr()->getAsCXXRecordDecl());
+         clang::QualType ftype = get_template_argument(type, i);
+         std::string ty = translate_type(ftype);
+         if ( !(is_builtin_type(ty)) ) {
+            if ( is_template_specialization(ftype, {"vector", "set", "optional"})) {
+               if ( get_template_argument(ftype)->isRecordType() )
+                  add_struct(get_template_argument(ftype).getTypePtr()->getAsCXXRecordDecl());
+            }
+            else if ( is_template_specialization(ftype, {"map"})) {
+               add_map(ftype);
+            }
+         }
       }
       abi_struct kv;
       std::string name = get_type(type);

--- a/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
+++ b/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
@@ -107,6 +107,19 @@ class abigen : public generation_utils {
       _abi.actions.insert(ret);
    }
 
+   void add_map(const clang::QualType& type) {
+      for (int i = 0; i < 2; ++i) {
+         if ( get_template_argument(type, i)->isRecordType() )
+            add_struct(get_template_argument(type, i).getTypePtr()->getAsCXXRecordDecl());
+      }
+      abi_struct kv;
+      std::string name = get_type(type);
+      kv.name = name.substr(0, name.length() - 2);
+      kv.fields.push_back( {"key", translate_type(get_template_argument(type))} );
+      kv.fields.push_back( {"value", translate_type(get_template_argument(type, 1))} );   
+      _abi.structs.insert(kv);
+   }
+
    void add_struct( const clang::CXXRecordDecl* decl ) {
       abi_struct ret;
       if ( decl->getNumBases() > 1 ) {
@@ -129,9 +142,12 @@ class abigen : public generation_utils {
          }
          else {
             ret.fields.push_back({field->getName().str(), get_type(field->getType())});
-            if ( is_template_specialization(field->getType(), {"vector", "optional"})) {
+            if ( is_template_specialization(field->getType(), {"vector", "set", "optional"})) {
                if ( get_template_argument(field->getType())->isRecordType() )
                      add_struct(get_template_argument(field->getType()).getTypePtr()->getAsCXXRecordDecl());
+            }
+            else if ( is_template_specialization(field->getType(), {"map"})) {
+               add_map(field->getType());
             }
          }
       }
@@ -153,9 +169,12 @@ class abigen : public generation_utils {
                add_typedef(param_type);
             if (param_type.getTypePtr()->isRecordType())
                add_struct( param_type.getTypePtr()->getAsCXXRecordDecl() );
-            else if (is_template_specialization(param_type, {"vector", "optional"})) {
+            else if (is_template_specialization(param_type, {"vector", "set", "optional"})) {
                if ( get_template_argument(param_type)->isRecordType())
                   add_struct(get_template_argument(param_type).getTypePtr()->getAsCXXRecordDecl());
+            }
+            else if ( is_template_specialization(param_type, {"map"})) {
+               add_map(param_type);
             }
          }
          new_struct.fields.push_back({param->getNameAsString(), get_type(param_type)});
@@ -353,7 +372,7 @@ class EosioMethodMatcher : public MatchFinder::MatchCallback {
                   if (param->getType().getTypePtr()->isRecordType() && !get_abigen_ref().is_builtin_type(param->getType())) {
                      get_abigen_ref().add_struct(param->getType().getTypePtr()->getAsCXXRecordDecl());
                   }
-                  if ( get_abigen_ref().is_template_specialization(param->getType(), {"vector", "optional"})) {
+                  if ( get_abigen_ref().is_template_specialization(param->getType(), {"vector", "set", "optional"})) {
                      if ( get_abigen_ref().get_template_argument(param->getType())->isRecordType() )
                         get_abigen_ref().add_struct(get_abigen_ref().get_template_argument(param->getType()).getTypePtr()->getAsCXXRecordDecl());
                   }
@@ -378,9 +397,12 @@ class EosioRecordMatcher : public MatchFinder::MatchCallback {
                         get_abigen_ref().add_typedef(field->getType());
                      if (field->getType()->isRecordType())
                         get_abigen_ref().add_struct(field->getType()->getAsCXXRecordDecl());
-                     if ( get_abigen_ref().is_template_specialization(field->getType(), {"vector", "optional"})) {
+                     if ( get_abigen_ref().is_template_specialization(field->getType(), {"vector", "set", "optional"})) {
                         if ( get_abigen_ref().get_template_argument(field->getType())->isRecordType() )
                            get_abigen_ref().add_struct(get_abigen_ref().get_template_argument(field->getType()).getTypePtr()->getAsCXXRecordDecl());
+                     }
+                     if ( get_abigen_ref().is_template_specialization(field->getType(), {"map"})) {
+                        get_abigen_ref().add_map(field->getType());
                      }
                   }
                }
@@ -394,9 +416,12 @@ class EosioRecordMatcher : public MatchFinder::MatchCallback {
                         get_abigen_ref().add_typedef(field->getType());
                      if (field->getType()->isRecordType())
                         get_abigen_ref().add_struct(field->getType()->getAsCXXRecordDecl());
-                     if ( get_abigen_ref().is_template_specialization(field->getType(), {"vector", "optional"})) {
+                     if ( get_abigen_ref().is_template_specialization(field->getType(), {"vector", "set", "optional"})) {
                         if ( get_abigen_ref().get_template_argument(field->getType())->isRecordType() )
                            get_abigen_ref().add_struct(get_abigen_ref().get_template_argument(field->getType()).getTypePtr()->getAsCXXRecordDecl());
+                     }
+                     if ( get_abigen_ref().is_template_specialization(field->getType(), {"map"})) {
+                        get_abigen_ref().add_map(field->getType());
                      }
                   }
             }


### PR DESCRIPTION
This fix the issue https://github.com/EOSIO/eosio.cdt/issues/192 
Now set::set & set::map is supported in abi generation, including nested std::map.
