### PR TITLE
fix struct/vector/set/map aliasing, nested aliasing

### DIFF
--- a/include/eosio/gen.hpp
+++ b/include/eosio/gen.hpp
@@ -292,6 +292,11 @@ struct generation_utils {
    inline std::string get_type_alias( const clang::QualType& t ) {
       if (is_name_type(get_base_type_name(t)))
          return "name";
+      if (auto tdt = llvm::dyn_cast<clang::TypedefType>(t)) {
+         clang::TypedefNameDecl *decl = tdt->getDecl();
+         if (decl)
+            return get_type(decl->getUnderlyingType());
+      }
       return get_type(clang::QualType(t).getCanonicalType());
    }
 

--- a/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
+++ b/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
@@ -50,11 +50,45 @@ auto               class_tmp_matcher    = classTemplateSpecializationDecl().bind
 class abigen : public generation_utils {
    public:
    abigen() : generation_utils([&](){throw abigen_ex;}) {}
+
+   clang::QualType getUnderlyingType(const clang::QualType& t) {
+      auto tdt = llvm::dyn_cast<clang::TypedefType>(t);
+      if (tdt) {
+         clang::TypedefNameDecl *decl = tdt->getDecl();
+         return decl->getUnderlyingType();
+      }
+      return clang::QualType();
+   }
+
    void add_typedef( const clang::QualType& t ) {
+
+      auto utype = getUnderlyingType(t);
+      if (utype.isNull() || utype->isPointerType()) 
+         return;
+
       abi_typedef ret;
       ret.new_type_name = get_base_type_name( t );
       ret.type = get_type_alias( t );
+      if (ret.type.find("<") != std::string::npos) return; // avoid adding typedef from interal std containers
       _abi.typedefs.insert(ret);
+
+      if (is_aliasing(utype)) {
+         add_typedef(utype); // nested alias
+      }
+      else if ( is_template_specialization(utype, {"vector", "set", "optional"})) {
+         if ( !(is_builtin_type(get_template_argument(utype))) ) {
+            if ( is_aliasing(get_template_argument(utype)))
+               add_typedef(get_template_argument(utype));
+            if ( get_template_argument(utype)->isRecordType() )
+               add_struct(get_template_argument(utype).getTypePtr()->getAsCXXRecordDecl());
+         }
+      }
+      else if ( is_template_specialization(utype, {"map"})) {
+         add_map(utype);
+      }
+      else if (is_cxx_record(utype)) {
+         add_struct(utype.getTypePtr()->getAsCXXRecordDecl());
+      }
    }
 
    void add_action( const clang::CXXRecordDecl* decl ) {
@@ -338,6 +372,10 @@ class abigen : public generation_utils {
          }
          for( auto t : set_of_tables ) {
             if (as.name == t.type)
+               return true;
+         }
+         for (auto t : _abi.typedefs) {
+            if (as.name == remove_suffix(t.type))
                return true;
          }
          return false;


### PR DESCRIPTION
This fixes alias issue in https://github.com/EOSIO/eosio.cdt/issues/187, also it aliasing for struct/vector/set/map, and nested aliasing:

sample code:
```
      typedef vector<uint32_t> vector_of_uint32;
      typedef std::map<int, string> map_of_str;
      typedef std::set<double>      set_of_double;
      
      struct int_struct {
         int value;
      };
      typedef int_struct int_struct_type; 
      struct short_struct { short value; };
      typedef short_struct short_struct_t;
      typedef double double_type;
      typedef std::map<double_type, short_struct_t> map_of_fstruct;
      struct nested_alias { int v; };
      typedef nested_alias nested_alias_1;
      typedef nested_alias_1 nested_alias_2;

      TABLE sample {
        vector_of_uint32 v = { 1, 2, 3};
        int_struct_type  i = { -4 };
        map_of_str       s = { { -5, "s_5"}, {-6, "s_6"}};
        set_of_double    d = { -3.14, -2.718};
        map_of_fstruct   f = {{-0.17, {-56}}};
        nested_alias_2   na = {-7};
      };
```

sample abi:
```
    "types": [
        {
            "new_type_name": "dbltype",
            "type": "float64"
        },
        {
            "new_type_name": "double_type",
            "type": "float64"
        },
        {
            "new_type_name": "float_type",
            "type": "float32"
        },
        {
            "new_type_name": "int_struct_type",
            "type": "int_struct"
        },
        {
            "new_type_name": "inttype",
            "type": "int32"
        },
        {
            "new_type_name": "map_of_fstruct",
            "type": "pair_double_type_short_struct_t[]"
        },
        {
            "new_type_name": "map_of_str",
            "type": "pair_int32_string[]"
        },
        {
            "new_type_name": "nested_alias_1",
            "type": "nested_alias"
        },
        {
            "new_type_name": "nested_alias_2",
            "type": "nested_alias_1"
        },
        {
            "new_type_name": "set_of_double",
            "type": "float64[]"
        },
        {
            "new_type_name": "short_struct_t",
            "type": "short_struct"
        },
        {
            "new_type_name": "vector_of_uint32",
            "type": "uint32[]"
        }
    ],

            "name": "sample",
            "base": "",
            "fields": [
                {
                    "name": "v",
                    "type": "vector_of_uint32"
                },
                {
                    "name": "i",
                    "type": "int_struct_type"
                },
                {
                    "name": "s",
                    "type": "map_of_str"
                },
                {
                    "name": "d",
                    "type": "set_of_double"
                },
                {
                    "name": "f",
                    "type": "map_of_fstruct"
                },
                {
                    "name": "na",
                    "type": "nested_alias_2"
                }
            ]
        },
```
get table output:
```
        "alias_data": {
          "v": [
            1,
            2,
            3
          ],
          "i": {
            "value": -4
          },
          "s": [{
              "key": -6,
              "value": "s_6"
            },{
              "key": -5,
              "value": "s_5"
            }
          ],
          "d": [
            "-3.14000000000000012",
            "-2.71799999999999997"
          ],
          "f": [{
              "key": "-0.17000000000000001",
              "value": {
                "value": -56
              }
            }
          ],
          "na": {
            "v": -7
          }
        },
```