### PR TITLE
fix tuple type abi gen

### DIFF
--- a/include/eosio/gen.hpp
+++ b/include/eosio/gen.hpp
@@ -243,7 +243,7 @@ struct generation_utils {
       }
       else if ( is_template_specialization( type, {"tuple"} )) {
          auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr());
-         auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt->desugar().getTypePtr());
+         auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt ? pt->desugar().getTypePtr() : type.getTypePtr());
          std::string ret = "tuple_";
          for (int i=0; i < tst->getNumArgs(); ++i) {
             ret += _translate_type(get_template_argument( type, i ));
@@ -254,7 +254,7 @@ struct generation_utils {
       }
       else if ( is_template_specialization( type, {} )) {
          auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr());
-         auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt->desugar().getTypePtr());
+         auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt ? pt->desugar().getTypePtr() : type.getTypePtr());
          std::string ret = tst->getTemplateName().getAsTemplateDecl()->getName().str()+"_";
          for (int i=0; i < tst->getNumArgs(); ++i) {
             ret += _translate_type(get_template_argument( type, i ));

--- a/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
+++ b/tools/extra/eosio_abigen_tool/eosio-abigen.cpp.in
@@ -112,7 +112,7 @@ class abigen : public generation_utils {
 
    void add_tuple(const clang::QualType& type) {
       auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr());
-      auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt->desugar().getTypePtr());
+      auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt ? pt->desugar().getTypePtr() : type.getTypePtr());
       if (!tst)
          throw abigen_ex;
       abi_struct tup;


### PR DESCRIPTION
This is to fix issue https://github.com/EOSIO/eosio.cdt/issues/234 of parsing type ```map<int, tuple<int, string, double> >```
