### PR TITLE
Adding eosio::structure attribute

### DIFF
--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -730,10 +730,12 @@ public:
   bool isEosioContract() const { return hasAttr<EosioContractAttr>(); }
   bool isEosioAction() const { return hasAttr<EosioActionAttr>(); }
   bool isEosioTable() const { return hasAttr<EosioTableAttr>(); }
+  bool isEosioStructure() const { return hasAttr<EosioStructureAttr>(); }
   bool isEosioIgnore() const { return hasAttr<EosioIgnoreAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioTableAttr*  getEosioTableAttr() const { return getAttr<EosioTableAttr>(); }
+  EosioStructureAttr*  getEosioStructureAttr() const { return getAttr<EosioStructureAttr>(); }
   EosioContractAttr*  getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
   EosioRicardianAttr*  getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
 

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1104,6 +1104,14 @@ def EosioTable : InheritableAttr {
    let Documentation = [EosioTableDocs];
 }
 
+def EosioStructure : InheritableAttr {
+   let Spellings = [CXX11<"eosio", "structure">, GNU<"eosio_structure">];
+   let Args = [StringArgument<"name", 1>];
+   let Subjects = SubjectList<[CXXRecord]>;
+   let MeaningfulToClassTemplateDefinition = 1;
+   let Documentation = [EosioStructureDocs];
+}
+
 def CXX11NoReturn : InheritableAttr {
   let Spellings = [CXX11<"", "noreturn", 200809>];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -1043,6 +1043,13 @@ The ``eosio::table`` attribute marks a record as being an eosio table.
   }];
 }
 
+def EosioStructureDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``eosio::structure`` attribute marks a struct as being an eosio structure.
+  }];
+}
+
 def NoSplitStackDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -489,6 +489,18 @@ static void handleEosioTableAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
                                 AL.getAttributeSpellingListIndex()));
 }
 
+static void handleEosioStructureAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
+  // Handle the cases where the attribute has a text message.
+  StringRef Str;
+  if (AL.isArgExpr(0) && AL.getArgAsExpr(0) &&
+      !S.checkStringLiteralArgumentAttr(AL, 0, Str))
+    return;
+
+  D->addAttr(::new (S.Context)
+                 EosioStructureAttr(AL.getRange(), S.Context, Str,
+                                AL.getAttributeSpellingListIndex()));
+}
+
 /// Applies the given attribute to the Decl without performing any
 /// additional semantic checking.
 template <typename AttrType>
@@ -6745,6 +6757,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_EosioTable:
     handleEosioTableAttribute(S, D, AL);
+    break;
+  case ParsedAttr::AT_EosioStructure:
+    handleEosioStructureAttribute(S, D, AL);
     break;
   case ParsedAttr::AT_EosioWasmABI:
     handleEosioABIAttribute(S, D, AL);


### PR DESCRIPTION
Adding eosio::structure custom attribute. Can be used for retrieving metadata. Example usage: struct [[eosio::structure]] fee_payer { /* fields */ };