### PR TITLE
Add a new action attribute "eosio::read_only"

### DIFF
--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -732,10 +732,13 @@ public:
   bool isEosioTable() const { return hasAttr<EosioTableAttr>(); }
   bool isEosioIgnore() const { return hasAttr<EosioIgnoreAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
+  bool isEosioReadOnly() const { return hasAttr<EosioReadOnlyAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioTableAttr*  getEosioTableAttr() const { return getAttr<EosioTableAttr>(); }
   EosioContractAttr*  getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
   EosioRicardianAttr*  getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
+  EosioReadOnlyAttr* getEosioReadOnlyAttr() const { return getAttr<EosioReadOnlyAttr>(); }
+
 
   CXXRecordDecl *getCanonicalDecl() override {
     return cast<CXXRecordDecl>(RecordDecl::getCanonicalDecl());
@@ -2152,10 +2155,12 @@ public:
   bool isEosioNotify() const { return hasAttr<EosioNotifyAttr>(); }
   bool isEosioContract() const { return hasAttr<EosioContractAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
+  bool isEosioReadOnly() const { return hasAttr<EosioReadOnlyAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioNotifyAttr* getEosioNotifyAttr() const { return getAttr<EosioNotifyAttr>(); }
   EosioContractAttr* getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
   EosioRicardianAttr* getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
+  EosioReadOnlyAttr* getEosioReadOnlyAttr() const { return getAttr<EosioReadOnlyAttr>(); }
 
   /// Returns true if the given operator is implicitly static in a record
   /// context.

--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -739,7 +739,6 @@ public:
   EosioRicardianAttr*  getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
   EosioReadOnlyAttr* getEosioReadOnlyAttr() const { return getAttr<EosioReadOnlyAttr>(); }
 
-
   CXXRecordDecl *getCanonicalDecl() override {
     return cast<CXXRecordDecl>(RecordDecl::getCanonicalDecl());
   }

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1096,6 +1096,12 @@ def EosioAction : InheritableAttr {
    let Documentation = [EosioActionDocs];
 }
 
+def EosioReadOnly : InheritableAttr {
+  let Spellings = [CXX11<"eosio", "read_only">, GNU<"eosio_read_only">];
+  let Subjects = SubjectList<[CXXRecord, CXXMethod]>;
+  let Documentation = [EosioReadOnlyDocs];
+}
+
 def EosioTable : InheritableAttr {
    let Spellings = [CXX11<"eosio", "table">, GNU<"eosio_table">];
    let Args = [StringArgument<"name", 1>];

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -1036,6 +1036,13 @@ The ``eosio::action`` attribute marks a method as being an eosio action.
   }];
 }
 
+def EosioReadOnlyDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``eosio::read_only`` attribute marks a method as being a read-only action.
+  }];
+}
+
 def EosioTableDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -479,7 +479,7 @@ static void handleEosioActionAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
 
 static void handleEosioReadOnlyAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
   D->addAttr(::new (S.Context)
-                 EosioActionAttr(AL.getRange(), S.Context, AL.getAttributeSpellingListIndex()));
+                 EosioReadOnlyAttr(AL.getRange(), S.Context, AL.getAttributeSpellingListIndex()));
 }
 
 static void handleEosioTableAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -477,6 +477,11 @@ static void handleEosioActionAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
                                 AL.getAttributeSpellingListIndex()));
 }
 
+static void handleEosioReadOnlyAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
+  D->addAttr(::new (S.Context)
+                 EosioActionAttr(AL.getRange(), S.Context, AL.getAttributeSpellingListIndex()));
+}
+
 static void handleEosioTableAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
   // Handle the cases where the attribute has a text message.
   StringRef Str;
@@ -6742,6 +6747,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_EosioAction:
     handleEosioActionAttribute(S, D, AL);
+    break;
+  case ParsedAttr::AT_EosioReadOnly:
+    handleEosioReadOnlyAttribute(S, D, AL);
     break;
   case ParsedAttr::AT_EosioTable:
     handleEosioTableAttribute(S, D, AL);


### PR DESCRIPTION
`eosio::read_only` is added as a Clang custom attribute. Example usage: [[eosio::action, eosio::read_only]] before method name.